### PR TITLE
Implement smoke.sh for Docker health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install ruff pytest
+      - run: ruff check .
+      - run: pytest -q
+
+  smoke:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - run: ./smoke.sh

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+services:
+  api:
+    image: alpine:3
+    command: ["sh", "-c", "while true; do sleep 1; done"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+  qdrant:
+    image: alpine:3
+    command: ["sh", "-c", "while true; do sleep 1; done"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 5
+  ollama:
+    image: alpine:3
+    command: ["sh", "-c", "while true; do sleep 1; done"]
+    healthcheck:
+      test: ["CMD", "true"]
+      interval: 1s
+      timeout: 1s
+      retries: 5

--- a/smoke.sh
+++ b/smoke.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/infra"
+
+docker compose up -d --build
+
+retries=60
+sleep_interval=2
+
+while [ "$retries" -gt 0 ]; do
+    statuses=$(docker compose ps --format json | jq -r '.[].State.Health.Status')
+    if echo "$statuses" | grep -q "unhealthy"; then
+        docker compose down
+        exit 1
+    fi
+    if echo "$statuses" | grep -vq "starting" && ! echo "$statuses" | grep -q "unhealthy"; then
+        docker compose down
+        exit 0
+    fi
+    sleep "$sleep_interval"
+    retries=$((retries - 1))
+done
+
+docker compose down
+exit 1


### PR DESCRIPTION
## Summary
- add a Docker Compose file with health checks for placeholder services
- implement `smoke.sh` to wait on container health
- make the smoke test executable
- add CI workflow to run lint, pytest and the smoke test

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858cacbe7448332b440ae0856e217e5