### PR TITLE
Fix db health test wait for healthy container

### DIFF
--- a/tests/test_db_health.py
+++ b/tests/test_db_health.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,24 @@ def test_db_health():
     if subprocess.run(["which", "docker"], capture_output=True).returncode != 0:
         pytest.skip("docker not available")
     subprocess.run(["docker", "compose", "up", "-d", "db"], cwd=INFRA, check=True)
+    container_id = subprocess.check_output(
+        ["docker", "compose", "ps", "-q", "db"], cwd=INFRA, text=True
+    ).strip()
+    inspect_fmt = (
+        "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}"
+    )
+    for _ in range(30):
+        status = subprocess.check_output(
+            ["docker", "inspect", "-f", inspect_fmt, container_id],
+            text=True,
+        ).strip()
+        if status == "healthy":
+            break
+        if status in {"exited", "unhealthy"}:
+            raise AssertionError(f"db container status {status}")
+        time.sleep(1)
+    else:
+        raise AssertionError("db did not become healthy")
     try:
         env = os.environ.copy()
         env["DATABASE_URL"] = (


### PR DESCRIPTION
## Summary
- wait for db container to reach healthy state in `test_db_health`

## Testing
- `pre-commit run --files tests/test_db_health.py`
- `pytest -q`