### PR TITLE
Fix seed & health scripts path

### DIFF
--- a/scripts/db_health.py
+++ b/scripts/db_health.py
@@ -1,4 +1,11 @@
 import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from helpdesk_ai.models import (
     ChatSession,
@@ -8,8 +15,6 @@ from helpdesk_ai.models import (
     Ticket,
     User,
 )
-from sqlalchemy import create_engine, func, select
-from sqlalchemy.orm import Session
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1,10 +1,15 @@
 import json
 import os
+import sys
 import uuid
+from pathlib import Path
 
-from helpdesk_ai.models import Base, Tenant, Ticket, User
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from helpdesk_ai.models import Base, Tenant, Ticket, User
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",


### PR DESCRIPTION
## Summary
- fix `ModuleNotFoundError` when running seed/demo scripts
- ensure both scripts can import the `helpdesk_ai` package without relying on PYTHONPATH

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859fa6a93f48332b4b0000dce4e2af8