### PR TITLE
Add phase 2 LLM runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,25 @@ jobs:
       - name: Pytest
         run: pytest -q
 
-  smoke:
+  llm-tests:
     needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - uses: docker/setup-buildx-action@v2
+      - run: docker compose up -d ollama
+      - run: pytest tests/llm -q
+      - run: docker compose down
+
+  smoke:
+    needs: llm-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,3 +8,16 @@ Use `./smoke.sh` to spin up the Docker Compose stack and verify that every
 service becomes healthy. Once up, the script applies Alembic migrations,
 loads demo seed data and runs a database health probe before tearing the stack
 down.
+
+## Local LLM runtime
+
+Phase 2 introduces an Ollama container running the Llama 3 8B model. Pull the
+model and verify the CLI:
+
+```bash
+ollama pull llama3
+ollama serve &
+curl http://localhost:11434/api/generate -d '{"model":"llama3","prompt":"ping"}'
+```
+
+The 70B variant requires over 140&nbsp;GB of VRAM and disk so remains optional.

--- a/infra/.dockerignore
+++ b/infra/.dockerignore
@@ -1,0 +1,3 @@
+*
+!Dockerfile.ollama
+!start_ollama.sh

--- a/infra/Dockerfile.ollama
+++ b/infra/Dockerfile.ollama
@@ -1,0 +1,4 @@
+FROM ollama/ollama:0.1.32
+COPY start_ollama.sh /start_ollama.sh
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl -fs http://localhost:11434/api/status | grep -q '"status":"ok"'
+ENTRYPOINT ["/start_ollama.sh"]

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -16,12 +16,22 @@ services:
       timeout: 1s
       retries: 5
   ollama:
-    image: alpine:3
-    command: ["sh", "-c", "while true; do sleep 1; done"]
+    build:
+      context: .
+      dockerfile: Dockerfile.ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
     healthcheck:
-      test: ["CMD", "true"]
-      interval: 1s
-      timeout: 1s
+      test: ["CMD", "curl", "-fs", "http://localhost:11434/api/status"]
+      interval: 10s
+      timeout: 5s
       retries: 5
   db:
     image: postgres:15
@@ -36,3 +46,6 @@ services:
       interval: 1s
       timeout: 1s
       retries: 5
+
+volumes:
+  ollama:

--- a/infra/start_ollama.sh
+++ b/infra/start_ollama.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+ollama serve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dev = [
     "alembic",
     "asyncpg",
     "psycopg2-binary",
+    "httpx",
+    "pytest-benchmark",
+    "anyio",
 ]
 
 [tool.pytest.ini_options]

--- a/smoke.sh
+++ b/smoke.sh
@@ -30,6 +30,8 @@ while [ "$retries" -gt 0 ]; do
             alembic -c alembic.ini upgrade head
         python scripts/seed_demo.py
         python scripts/db_health.py
+        curl -fsS -X POST http://localhost:11434/api/generate \
+            -d '{"model":"llama3","prompt":"ping","stream":false}' >/dev/null
         docker compose -f "$COMPOSE_FILE" down
         exit 0
     fi

--- a/src/helpdesk_ai/llm/ollama_client.py
+++ b/src/helpdesk_ai/llm/ollama_client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+BASE_URL = "http://localhost:11434/api"
+
+
+class OllamaClient:
+    def __init__(self, base_url: str = BASE_URL) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.Client()
+
+    def _request(
+        self, method: str, path: str, json: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        url = f"{self.base_url}{path}"
+        for delay in (0.0, 0.5, 1.0):
+            try:
+                resp = self._client.request(method, url, json=json, timeout=30)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPError:
+                if delay == 1.0:
+                    raise
+                time.sleep(delay)
+        raise RuntimeError("unreachable")
+
+    def status(self) -> dict[str, Any]:
+        return self._request("GET", "/status").json()
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        system: str | None = None,
+        temperature: float = 0.7,
+        model: str = "llama3",
+    ) -> str:
+        payload: dict[str, Any] = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature},
+        }
+        if system is not None:
+            payload["system"] = system
+        return (
+            self._request("POST", "/generate", json=payload).json().get("response", "")
+        )
+
+    def embed(self, text: str, *, model: str = "llama3") -> list[float]:
+        payload = {"model": model, "prompt": text}
+        return (
+            self._request("POST", "/embeddings", json=payload)
+            .json()
+            .get("embedding", [])
+        )

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -1,0 +1,85 @@
+import subprocess
+import time
+from pathlib import Path
+
+import anyio
+import httpx
+import pytest
+from helpdesk_ai.llm.ollama_client import OllamaClient
+
+ROOT = Path(__file__).resolve().parents[1]
+INFRA = ROOT / "infra"
+
+
+def _wait_healthy(container_id: str) -> None:
+    inspect_fmt = (
+        "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}"
+    )
+    for _ in range(60):
+        status = subprocess.check_output(
+            ["docker", "inspect", "-f", inspect_fmt, container_id], text=True
+        ).strip()
+        if status == "healthy":
+            return
+        if status in {"exited", "unhealthy"}:
+            raise AssertionError(f"ollama container status {status}")
+        time.sleep(1)
+    raise AssertionError("ollama did not become healthy")
+
+
+@pytest.fixture(scope="module")
+def ollama_container():
+    if subprocess.run(["which", "docker"], capture_output=True).returncode != 0:
+        pytest.skip("docker not available")
+    subprocess.run(["docker", "compose", "up", "-d", "ollama"], cwd=INFRA, check=True)
+    container_id = subprocess.check_output(
+        ["docker", "compose", "ps", "-q", "ollama"], cwd=INFRA, text=True
+    ).strip()
+    try:
+        _wait_healthy(container_id)
+        yield
+    finally:
+        subprocess.run(["docker", "compose", "down"], cwd=INFRA, check=True)
+
+
+def test_status(ollama_container):
+    client = OllamaClient()
+    assert client.status()["status"] == "ok"
+
+
+def test_generate(ollama_container):
+    client = OllamaClient()
+    text = client.generate("Hello")
+    assert text
+
+
+def test_embeddings(ollama_container):
+    client = OllamaClient()
+    vec = client.embed("hello world")
+    assert len(vec) == 768
+
+
+def test_latency_budget(ollama_container, benchmark):
+    client = OllamaClient()
+
+    def _call():
+        client.generate("hello" * 4)
+
+    result = benchmark(_call)
+    assert result.stats["mean"] < 2.0
+
+
+@pytest.mark.anyio
+async def test_concurrent_generation(ollama_container):
+    async def worker(idx: int) -> str:
+        async with httpx.AsyncClient() as ac:
+            resp = await ac.post(
+                "http://localhost:11434/api/generate",
+                json={"model": "llama3", "prompt": f"hi {idx}", "stream": False},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            return resp.json().get("response", "")
+
+    results = await anyio.gather(*[worker(i) for i in range(10)])
+    assert all(results)


### PR DESCRIPTION
## Summary
- implement phase 2 LLM runtime based on AGENTS.md
- add Ollama Dockerfile and compose configuration
- create Python client and LLM tests
- update smoke script and CI workflow
- document local LLM usage in README

## Testing
- `pre-commit run --files tests/llm/test_ollama.py src/helpdesk_ai/llm/ollama_client.py README.md infra/compose.yml pyproject.toml smoke.sh .github/workflows/ci.yml infra/.dockerignore infra/Dockerfile.ollama infra/start_ollama.sh src/helpdesk_ai/llm/__init__.py`
- `pytest -q`