### PR TITLE
Fix Docker compose when no GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,8 @@ ollama serve &
 curl http://localhost:11434/api/generate -d '{"model":"llama3","prompt":"ping"}'
 ```
 
+The Compose stack runs the model on CPU unless you add a GPU reservation. If you
+have an NVIDIA card, uncomment the `deploy` block in `infra/compose.yml` or add
+an equivalent `--gpus` flag when running Docker.
+
 The 70B variant requires over 140&nbsp;GB of VRAM and disk so remains optional.

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -23,11 +23,6 @@ services:
       - "11434:11434"
     volumes:
       - ollama:/root/.ollama
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://localhost:11434/api/status"]
       interval: 10s


### PR DESCRIPTION
## Summary
- make ollama's GPU usage optional in Docker Compose
- document how to enable GPU in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`