### PR TITLE
Fix infra paths in tests

### DIFF
--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import anyio
 import httpx
 import pytest
+
 from helpdesk_ai.llm.ollama_client import OllamaClient
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 INFRA = ROOT / "infra"
 
 

--- a/tests/test_db_health.py
+++ b/tests/test_db_health.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 INFRA = ROOT / "infra"
 
 


### PR DESCRIPTION
## Summary
- fix path calculation for infra dir used in tests

## Testing
- `pytest -q`