### PR TITLE
Switch to arm64 Ollama image

### DIFF
--- a/infra/Dockerfile.ollama
+++ b/infra/Dockerfile.ollama
@@ -1,4 +1,4 @@
-FROM ollama/ollama:0.1.32
+FROM --platform=linux/arm64 ollama/ollama:0.1.32
 COPY start_ollama.sh /start_ollama.sh
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl -fs http://localhost:11434/api/status | grep -q '"status":"ok"'
 ENTRYPOINT ["/start_ollama.sh"]

--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -16,6 +16,7 @@ services:
       timeout: 1s
       retries: 5
   ollama:
+    platform: linux/arm64
     build:
       context: .
       dockerfile: Dockerfile.ollama


### PR DESCRIPTION
## Summary
- use the arm64 base image in `Dockerfile.ollama`
- pin the `ollama` service in Compose to arm64

## Testing
- `pre-commit run --files infra/Dockerfile.ollama infra/compose.yml`
- `pytest -q`