### PR TITLE
Fix Ollama status check

### DIFF
--- a/scripts/load_docs.py
+++ b/scripts/load_docs.py
@@ -64,7 +64,7 @@ def _points(
         points.append(
             PointStruct(
                 # Qdrant requires point IDs to be a valid UUID or an integer.
-                # We can generate a deterministic UUID from the doc checksum and chunk index.
+                # Use a deterministic UUID derived from the checksum and index.
                 id=str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{doc_id}-{idx}")),
                 vector=vec,
                 payload={

--- a/src/helpdesk_ai/llm/ollama_client.py
+++ b/src/helpdesk_ai/llm/ollama_client.py
@@ -29,7 +29,14 @@ class OllamaClient:
         raise RuntimeError("unreachable")
 
     def status(self) -> dict[str, Any]:
-        return self._request("GET", "/status").json()
+        """Return a simple health status for the Ollama server."""
+        # Older versions of Ollama exposed ``/status`` which returned
+        # ``{"status": "ok"}``. Newer releases dropped that route so we
+        # query ``/tags`` instead. The exact payload is not important here –
+        # a 200 response proves the daemon is reachable.
+
+        self._request("GET", "/tags")
+        return {"status": "ok"}
 
     def generate(
         self,

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -3,7 +3,6 @@ import time
 from pathlib import Path
 
 import asyncio
-import anyio
 import httpx
 import pytest
 


### PR DESCRIPTION
## Summary
- query `/tags` to validate Ollama health
- fix long comment in `load_docs` to satisfy Ruff
- drop unused `anyio` import

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for several optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685cc5f4b0c88332a1c8bf3e5c898adc