### PR TITLE
Fix sample PDF to yield multiple chunks

### DIFF
--- a/docs/sample_docs/sample.pdf
+++ b/docs/sample_docs/sample.pdf
@@ -6,28 +6,29 @@
 /Contents 4 0 R>>
 endobj
 4 0 obj
-<</Filter /FlateDecode /Length 284>>
+<</Filter /FlateDecode /Length 246>>
 stream
-xJCQE|ŔlϼΣMaeq `_NHnu`aZBo]fĂRh9Ԇ5Zjy>h^{*qvo{z⚖hm0QN:PUI\tF2Z@ZuC	V=Qj3h	
-HcrB'Q6zc؄P&&1Ji;9	&RVNX%AJ݄W"=A^I)?IxMn+AaAgR4
-endstream
+x͔j0EYPzHER?lqq\Lp
+)mÙ(X{q%A*<B#	ax	Pݦick]B2ll],sU:LWvhlѨoIДD{u_G
+ڹ);_|ħZvY&B/AVփEmˬzȴ=ZbB`FϷ1N;Nr
+/Kids [3 0 R ]
+/Count 1
 endobj
 5 0 obj
-<</Type /Page
-/Parent 1 0 R
-/Resources 2 0 R
-/Contents 6 0 R>>
-endobj
+/F1 5 0 R
 6 0 obj
-<</Filter /FlateDecode /Length 272>>
-stream
-x=KA>bJmw^vgMae_ `)F2p#)NߛIw[&B@2x
-w/t3_gZcO@;:޿N{z~_&ՁuՒP]儕6+mj¶q+k	k&RF+Fl+w&2qHJGn]_um]	$Mt-X+5Kt%n+܂%R`Z+vGؖ܂܈
-endstream
-endobj
-1 0 obj
-<</Type /Pages
-/Kids [3 0 R 5 0 R ]
+/CreationDate (D:20250626041206)
+7 0 obj
+0 8
+0000000403 00000 n 
+0000000586 00000 n 
+0000000490 00000 n 
+0000000690 00000 n 
+0000000799 00000 n 
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+902
 /Count 2
 /MediaBox [0 0 595.28 841.89]
 >>


### PR DESCRIPTION
## Summary
- update `docs/sample_docs/sample.pdf` with longer sample text

## Testing
- `pytest tests/knowledge/test_chunk_counts.py -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_685cc5f92f4883329b39c639efb27ab7