### PR TITLE
Add text-filled sample PDF

### DIFF
--- a/docs/sample_docs/sample.pdf
+++ b/docs/sample_docs/sample.pdf
@@ -1,53 +1,50 @@
 %PDF-1.3
-3 0 obj
-<</Type /Page
-/Parent 1 0 R
-/Resources 2 0 R
-/Contents 4 0 R>>
-endobj
-4 0 obj
-<</Filter /FlateDecode /Length 284>>
-stream
-xJCQE|ŔlϼΣMaeq `_NHnu`aZBo]fĂRh9Ԇ5Zjy>h^{*qvo{z⚖hm0QN:PUI\tF2Z@ZuC	V=Qj3h	
-HcrB'Q6zc؄P&&1Ji;9	&RVNX%AJ݄W"=A^I)?IxMn+AaAgR4
-endstream
-endobj
-5 0 obj
-<</Type /Page
-/Parent 1 0 R
-/Resources 2 0 R
-/Contents 6 0 R>>
-endobj
-6 0 obj
-<</Filter /FlateDecode /Length 272>>
-stream
-x=KA>bJmw^vgMae_ `)F2p#)NߛIw[&B@2x
-w/t3_gZcO@;:޿N{z~_&ՁuՒP]儕6+mj¶q+k	k&RF+Fl+w&2qHJGn]_um]	$Mt-X+5Kt%n+܂%R`Z+vGؖ܂܈
-endstream
-endobj
-1 0 obj
-<</Type /Pages
-/Kids [3 0 R 5 0 R ]
-/Count 2
-/MediaBox [0 0 595.28 841.89]
->>
-endobj
-7 0 obj
-<</Type /Font
-/BaseFont /Helvetica
-/Subtype /Type1
-/Encoding /WinAnsiEncoding
->>
-endobj
+% ReportLab Generated PDF document http://www.reportlab.com
+<<
+/F1 2 0 R
 2 0 obj
 <<
-/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font <<
-/F1 7 0 R
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+3 0 obj
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250626055058+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250626055058+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+endobj
+6 0 obj
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+7 0 obj
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 644
+stream
+GarVLbAQ)h%(taRk*QnlGIL,jF'gp27=Z5g1D4O\e\_uqD>X((]UMV+Kakqc35_/XI)+UA_tJ0apcRQlm/`":(ag;@L)Z(qpblI3qVb\*ZcC)sH]/Qg%i!X2\Gpl5.2Pt_?/_*8IS-'r9C%+J&V\Q678C:Z;^G"mfKtj`?)c1UBO)=:4@J(7I)>Xof93.",UWrX%mi0H::\UWC<"JS$WT[?Ki&XYaGE^;nS@*:[:I=Xlj)<K9n]V%ie?4O@#@r6.!"-dA]h/rD$B!3'm8=8#;HlVb_eNkcm$VqPA@`sP/d_T-[;&CW6-Xb`21(_EJNm,@knfgBWa6^C<>j^jFBdP[?2g>Ep"G_V%R^N!V_:MNT`^Qdj.[^im,?A(oa;@Q6_,5abarXbYXcJj(.[2fDoue*@qcNdq59\1N"/fih]"$'M4PoHte9UHaDQs/\nO"(ZS%T%&c1>9obQN)9J#8X]gh"\O@,h7,Vt[J(aJMb&Qem71Hh?D-V>$-_%85eG@a$liuFJWK$l6QC,n+"Y2XlJc0@T9f-ICk=-'Go#)Qi%RD3/.H'eOW43&`MH()[hEineO5RPDI#7&R?&bo-Ze7.^Q*t)G-g3=kCl@@LKC;doMe:k%%Ad3B28q55p1rXP0*@7nf)~>endstream
+0 8
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
+/ID 
+[<9b7991adfe472179e0ce11f73b809428><9b7991adfe472179e0ce11f73b809428>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
 >>
-/XObject <<
->>
->>
+1561
 endobj
 8 0 obj
 <<


### PR DESCRIPTION
## Summary
- update sample.pdf with longer dummy content so chunking tests have enough text

## Testing
- `pre-commit run --files docs/sample_docs/sample.pdf`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qdrant_client')*

------
https://chatgpt.com/codex/tasks/task_e_685cdf51601c833284655a69ef52c865