### PR TITLE
Add multi-paragraph sample.pdf

### DIFF
--- a/docs/sample_docs/sample.pdf
+++ b/docs/sample_docs/sample.pdf
@@ -1,37 +1,68 @@
-%PDF-1.4
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R >>
+<<
+/F1 2 0 R
+>>
 endobj
 2 0 obj
-<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
 endobj
 3 0 obj
-<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+<<
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
 endobj
 4 0 obj
-<< /Length 2310 >>
-stream
-BT
-/F1 12 Tf
-72 720 Td
-(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.) Tj
-ET
-endstream
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
 endobj
 5 0 obj
-<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+<<
+/Author (anonymous) /CreationDate (D:20250626201656+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250626201656+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 664
+>>
+stream
+Gaqc46#PF2&A70@F%hKWNIq3o-YNqlaIrie?qmak`Y>D690;S-];/BKJH`q<G@tQ$7N:.KB@FT>$p=:ZZ/&gZJ:>H!Z$Sn=MVnAlSo6ecIm3(;O+,)cDdA)]@Mtq6=cdJoJqXh3M&)"/[`_A9iYd5pD*,CDeNtF3?t-+U>3&uIr!iTDqX:r=;7fA<A/GXb<oaT4r#mc&KY7a,I%6_kn>`TMlEmB/.Y6Ra6t8j#i),UrP;kqdT5\m]?"e`r:"nn;Z&jc)o)_*p3n8fgM.rWRkO(Q2"7,8:Cgn6ap0:KX\:NsD4"$D*;X,tB#O1_7Oj;EeNYJ9!ifK'6."_oH'h\/k;5\JkASSmCEZgQTcBsM+=%-n^F\k!,nu8CCc;tK&\_RU/it7UU;K)9UI=ir*S#i8rkL5>aLd'ENM=XWsH8!S1<@H;Q<.uT+r@@C>Wgu`)hhsOZ^WNm*TrNLlo_"HPdia[s@2Ydg1H.$8eq;I]_&nS:V=N;e9*[=_bsXFD]ZTG$`gCAPdQb2U1L`rN1g@/!DDJTDNMeRESZO'JJGMfhDPHP.V5i-pe&m1XY2e*lq:+D$A&2\l9n9_jYY1!HS6/gdAX>iFFpGa^VGBW`W]e!m:u"J$9_"nGD4$*b12S#:qn"m;<fOB3%pt"@QP)7W!5j(MU]~>endstream
 endobj
 xref
-0 7
-0000000000 65535 f
-0000000000 00000 n
-0000000009 00000 n
-0000000058 00000 n
-0000000115 00000 n
-0000000241 00000 n
-0000002603 00000 n
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000404 00000 n 
+0000000472 00000 n 
+0000000768 00000 n 
+0000000827 00000 n 
 trailer
-<< /Root 1 0 R /Size 7 >>
+<<
+/ID 
+[<dc0bf264fa4246ca2d5a174668719934><dc0bf264fa4246ca2d5a174668719934>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
 startxref
-2673
+1581
 %%EOF


### PR DESCRIPTION
## Summary
- add a replacement `sample.pdf` with multiple short paragraphs for line wrapping tests

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q tests/knowledge/test_chunk_counts.py` *(fails: ModuleNotFoundError: No module named 'unstructured')*