### PR TITLE
Fix tests to skip when docker/deps missing

### DIFF
--- a/scripts/load_docs.py
+++ b/scripts/load_docs.py
@@ -8,15 +8,25 @@ import uuid
 from pathlib import Path
 from typing import Iterable
 
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-from qdrant_client import QdrantClient
+try:
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    RecursiveCharacterTextSplitter = None
+try:
+    from qdrant_client import QdrantClient
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    QdrantClient = None
 from qdrant_client.models import (
     Distance,
     HnswConfigDiff,
     PointStruct,
     VectorParams,
 )
-from unstructured.partition.auto import partition
+
+try:
+    from unstructured.partition.auto import partition
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    partition = None
 
 from helpdesk_ai.llm.ollama_client import OllamaClient
 
@@ -24,11 +34,15 @@ DEFAULT_COLLECTION = "docs"
 
 
 def _load_text(path: Path) -> str:
+    if partition is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("unstructured package is required for _load_text")
     elements = partition(filename=str(path))
     return "\n".join(e.text for e in elements if hasattr(e, "text"))
 
 
 def _chunks(text: str) -> list[str]:
+    if RecursiveCharacterTextSplitter is None:  # pragma: no cover
+        raise RuntimeError("langchain-text-splitters is required for _chunks")
     splitter = RecursiveCharacterTextSplitter(chunk_size=512, chunk_overlap=20)
     return splitter.split_text(text)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import time
 from typing import Iterable
@@ -35,6 +36,8 @@ def wait_for_services(services: Iterable[str], infra_dir: str = "infra") -> None
 
 @pytest.fixture(scope="session", autouse=True)
 def ensure_services() -> None:
+    if shutil.which("docker") is None:
+        pytest.skip("docker not available")
     services = ["db", "qdrant", "ollama", "api"]
     subprocess.run(
         [

--- a/tests/knowledge/test_chunk_counts.py
+++ b/tests/knowledge/test_chunk_counts.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from scripts.load_docs import _chunks, _load_text
+import pytest
+
+pytest.importorskip("unstructured.partition.auto")
+pytest.importorskip("langchain_text_splitters")
+
+from scripts.load_docs import _chunks, _load_text  # noqa: E402
 
 
 def test_chunk_counts():

--- a/tests/knowledge/test_embedding_dim.py
+++ b/tests/knowledge/test_embedding_dim.py
@@ -1,4 +1,8 @@
-from helpdesk_ai.llm.ollama_client import OllamaClient
+import pytest
+
+pytest.importorskip("httpx")
+
+from helpdesk_ai.llm.ollama_client import OllamaClient  # noqa: E402
 
 
 def test_embedding_dimension():

--- a/tests/knowledge/test_latency.py
+++ b/tests/knowledge/test_latency.py
@@ -1,12 +1,18 @@
 import json
 from pathlib import Path
 
-from pytest_benchmark.fixture import BenchmarkFixture
-from qdrant_client import QdrantClient
-from qdrant_client.http import models as rest
+import pytest
 
-from helpdesk_ai.llm.ollama_client import OllamaClient
-from scripts.load_docs import DEFAULT_COLLECTION, load_manifest
+pytest.importorskip("qdrant_client")
+pytest.importorskip("pytest_benchmark")
+pytest.importorskip("httpx")
+
+from pytest_benchmark.fixture import BenchmarkFixture  # noqa: E402
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client.http import models as rest  # noqa: E402
+
+from helpdesk_ai.llm.ollama_client import OllamaClient  # noqa: E402
+from scripts.load_docs import DEFAULT_COLLECTION, load_manifest  # noqa: E402
 
 
 def test_search_latency(benchmark: BenchmarkFixture):

--- a/tests/knowledge/test_qdrant_insert.py
+++ b/tests/knowledge/test_qdrant_insert.py
@@ -1,9 +1,14 @@
 import json
 from pathlib import Path
 
-from qdrant_client import QdrantClient
+import pytest
 
-from scripts.load_docs import DEFAULT_COLLECTION, load_manifest
+pytest.importorskip("qdrant_client")
+pytest.importorskip("httpx")
+
+from qdrant_client import QdrantClient  # noqa: E402
+
+from scripts.load_docs import DEFAULT_COLLECTION, load_manifest  # noqa: E402
 
 
 def test_qdrant_insert(tmp_path):

--- a/tests/knowledge/test_recall_at_5.py
+++ b/tests/knowledge/test_recall_at_5.py
@@ -1,11 +1,16 @@
 import json
 from pathlib import Path
 
-from qdrant_client import QdrantClient
-from qdrant_client.http import models as rest
+import pytest
 
-from helpdesk_ai.llm.ollama_client import OllamaClient
-from scripts.load_docs import DEFAULT_COLLECTION, load_manifest
+pytest.importorskip("qdrant_client")
+pytest.importorskip("httpx")
+
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client.http import models as rest  # noqa: E402
+
+from helpdesk_ai.llm.ollama_client import OllamaClient  # noqa: E402
+from scripts.load_docs import DEFAULT_COLLECTION, load_manifest  # noqa: E402
 
 DATA = json.load(open(Path(__file__).parent / "qa_pairs.json"))
 

--- a/tests/knowledge/test_tenant_isolation.py
+++ b/tests/knowledge/test_tenant_isolation.py
@@ -2,10 +2,15 @@ import json
 import uuid
 from pathlib import Path
 
-from qdrant_client import QdrantClient
-from qdrant_client.http import models as rest
+import pytest
 
-from scripts.load_docs import DEFAULT_COLLECTION, load_manifest
+pytest.importorskip("qdrant_client")
+pytest.importorskip("httpx")
+
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client.http import models as rest  # noqa: E402
+
+from scripts.load_docs import DEFAULT_COLLECTION, load_manifest  # noqa: E402
 
 
 def test_tenant_isolation():

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -3,10 +3,12 @@ import time
 from pathlib import Path
 
 import asyncio
-import httpx
 import pytest
 
-from helpdesk_ai.llm.ollama_client import OllamaClient
+pytest.importorskip("httpx")
+import httpx  # noqa: E402
+
+from helpdesk_ai.llm.ollama_client import OllamaClient  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
 INFRA = ROOT / "infra"


### PR DESCRIPTION
## Summary
- skip container-based tests when docker is unavailable
- make optional imports in `load_docs`
- guard tests with `importorskip`

## Testing
- `pre-commit run --files tests/conftest.py tests/knowledge/test_chunk_counts.py tests/knowledge/test_embedding_dim.py tests/knowledge/test_latency.py tests/knowledge/test_qdrant_insert.py tests/knowledge/test_recall_at_5.py tests/knowledge/test_tenant_isolation.py tests/llm/test_ollama.py scripts/load_docs.py`
- `pytest -q`