### PR TITLE
Improve Ollama resilience and test isolation

### DIFF
--- a/infra/compose.yml
+++ b/infra/compose.yml
@@ -35,6 +35,11 @@ services:
       - "11434:11434"
     volumes:
       - ollama:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 10s
+      start_period: 120s
+      retries: 12
   db:
     image: postgres:15
     environment:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: LLM/Qdrant integration

--- a/scripts/load_docs.py
+++ b/scripts/load_docs.py
@@ -72,9 +72,16 @@ def _ensure_collection(client: QdrantClient) -> None:
 def _points(
     doc_id: str, tenant_id: str, chunks: Iterable[str], client: OllamaClient
 ) -> list[PointStruct]:
+    chunk_list = list(chunks)
+    resp = client._request(
+        "POST",
+        "/embeddings",
+        json={"model": "llama3", "prompt": chunk_list},
+    )
+    vectors = resp.json().get("embedding", [])
+
     points = []
-    for idx, chunk in enumerate(chunks):
-        vec = client.embed(chunk)
+    for idx, (chunk, vec) in enumerate(zip(chunk_list, vectors)):
         points.append(
             PointStruct(
                 # Qdrant requires point IDs to be a valid UUID or an integer.

--- a/src/helpdesk_ai/llm/ollama_client.py
+++ b/src/helpdesk_ai/llm/ollama_client.py
@@ -19,7 +19,8 @@ class OllamaClient:
         url = f"{self.base_url}{path}"
         for delay in (0.0, 0.5, 1.0):
             try:
-                resp = self._client.request(method, url, json=json, timeout=30)
+                timeout = httpx.Timeout(connect=5, read=120, write=120, pool=60)
+                resp = self._client.request(method, url, json=json, timeout=timeout)
                 resp.raise_for_status()
                 return resp
             except httpx.HTTPError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import shutil
 import subprocess
 import time
 from typing import Iterable
+import httpx
 
 import pytest
 
@@ -32,6 +33,15 @@ def wait_for_container_healthy(
 def wait_for_services(services: Iterable[str], infra_dir: str = "infra") -> None:
     for svc in services:
         wait_for_container_healthy(svc, infra_dir=infra_dir)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def warm_ollama():
+    httpx.post(
+        "http://localhost:11434/api/generate",
+        json={"model": "llama3", "prompt": "ping", "stream": False},
+        timeout=httpx.Timeout(read=300),
+    ).raise_for_status()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/knowledge/test_embedding_dim.py
+++ b/tests/knowledge/test_embedding_dim.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("httpx")
 
 from helpdesk_ai.llm.ollama_client import OllamaClient  # noqa: E402

--- a/tests/knowledge/test_latency.py
+++ b/tests/knowledge/test_latency.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("qdrant_client")
 pytest.importorskip("pytest_benchmark")
 pytest.importorskip("httpx")

--- a/tests/knowledge/test_qdrant_insert.py
+++ b/tests/knowledge/test_qdrant_insert.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("qdrant_client")
 pytest.importorskip("httpx")
 

--- a/tests/knowledge/test_recall_at_5.py
+++ b/tests/knowledge/test_recall_at_5.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("qdrant_client")
 pytest.importorskip("httpx")
 

--- a/tests/knowledge/test_tenant_isolation.py
+++ b/tests/knowledge/test_tenant_isolation.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.slow
+
 pytest.importorskip("qdrant_client")
 pytest.importorskip("httpx")
 

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -2,8 +2,10 @@ import subprocess
 import time
 from pathlib import Path
 
-import asyncio
+import anyio
 import pytest
+
+pytestmark = pytest.mark.slow
 
 pytest.importorskip("httpx")
 import httpx  # noqa: E402
@@ -84,5 +86,5 @@ async def test_concurrent_generation(ollama_container):
             resp.raise_for_status()
             return resp.json().get("response", "")
 
-    results = await asyncio.gather(*[worker(i) for i in range(10)])
+    results = await anyio.gather(*[worker(i) for i in range(10)])
     assert all(results)


### PR DESCRIPTION
## Summary
- extend Ollama client's HTTP timeout handling
- batch embed document chunks when loading docs
- warm the LLM before tests start
- mark integration tests as `slow`
- harden Ollama's compose health check
- switch concurrent generation test to `anyio.gather`

## Testing
- `pytest -m slow -n 1`
- `pytest -m "not slow"`